### PR TITLE
Add HF datasets into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     # Miscellanous
     "h5py==3.10.0",
     "opencv-python==4.9.0.80",
+    "datasets==2.16.1",
 ]
 
 [tool.black]


### PR DESCRIPTION
Adds HuggingFace's `datasets` package to the pyproject.toml file to add to the packages in the docker image during build.