### PR TITLE
Recommended fix for the documentation

### DIFF
--- a/docs/Contribution.rst
+++ b/docs/Contribution.rst
@@ -323,8 +323,7 @@ Copy the ``.dropboxignore`` file to work for Maestral:
     synchronized across devices.
 
 .. note::
-
-    Please be aware that on busy computer clusters, initiating the Maestral 
+    Please be aware that on busy computer clusters, initiating the Maestral
     might take a few trials.
 
 Freezing the repositories for publication

--- a/docs/Contribution.rst
+++ b/docs/Contribution.rst
@@ -322,6 +322,11 @@ Copy the ``.dropboxignore`` file to work for Maestral:
     Do not create a symbolic link else the ``.mignore`` file will not be
     synchronized across devices.
 
+.. note::
+
+    Please be aware that on busy computer clusters, initiating the Maestral 
+    might take a few trials.
+
 Freezing the repositories for publication
 -----------------------------------------
 

--- a/docs/Execution_On_a_Slurm_cluster.rst
+++ b/docs/Execution_On_a_Slurm_cluster.rst
@@ -13,11 +13,6 @@ Run a python script
     The following command was designed for the Béluga cluster. It will most
     likely need refining on other clusters.
 
-.. note::
-    By default, the Apptainer's local timezone is set to UTC, but when it's
-    run, the system's local timezone will overwrite it. If you'd like to set
-    it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE`` flag to the execution command.
-
 .. code-block:: bash
 
     # Example of a simple MNIST training run

--- a/docs/Execution_On_a_Slurm_cluster.rst
+++ b/docs/Execution_On_a_Slurm_cluster.rst
@@ -14,10 +14,9 @@ Run a python script
     likely need refining on other clusters.
 
 .. note::
-    By default, the Apptainer's local timezone is set to UTC, but when it's 
-    run, the system's local timezone will overwrite it. If you'd 
-    like to set it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE`` 
-    flag to the execution command.   
+    By default, the Apptainer's local timezone is set to UTC, but when it's
+    run, the system's local timezone will overwrite it. If you'd like to set
+    it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE`` flag to the execution command.
 
 .. code-block:: bash
 

--- a/docs/Execution_On_a_Slurm_cluster.rst
+++ b/docs/Execution_On_a_Slurm_cluster.rst
@@ -13,6 +13,12 @@ Run a python script
     The following command was designed for the Béluga cluster. It will most
     likely need refining on other clusters.
 
+.. note::
+    By default, the Apptainer's local timezone is set to UTC, but when it's 
+    run, the system's local timezone will overwrite it. If you'd 
+    like to set it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE`` 
+    flag to the execution command.   
+
 .. code-block:: bash
 
     # Example of a simple MNIST training run

--- a/docs/Execution_On_an_Ubuntu_machine.rst
+++ b/docs/Execution_On_an_Ubuntu_machine.rst
@@ -19,6 +19,11 @@ On an Ubuntu machine
 
     Make sure to remove the above flags if you are not using a GPU.
 
+.. note:: 
+    By default, the Podman container's timezone is either set to the timezone of the local 
+    where it is built or to the UTC. To change the timezone of the container, add
+    ``--tz=local`` flag to the execution command above.
+
 Run a python script
 -------------------
 
@@ -27,6 +32,12 @@ Run a python script
 
     Run ``cd ${CNEUROMAX_PATH}/cneuromax`` before the following command to get
     tab completion for the ``task`` argument.
+
+.. note::
+    By default, Docker's local timezone is set to UTC, and all the Docker operations
+    will run according to UTC regardless of the host machine's timezone. If you 
+    would like to set it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE`` 
+    flag to the execution command below.
 
 .. code-block:: bash
 

--- a/docs/Execution_On_an_Ubuntu_machine.rst
+++ b/docs/Execution_On_an_Ubuntu_machine.rst
@@ -20,9 +20,9 @@ On an Ubuntu machine
     Make sure to remove the above flags if you are not using a GPU.
 
 .. note::
-    By default, the Podman container's timezone is either set to the timezone of the local
-    where it is built or to the UTC. To change the timezone of the container, add
-    ``--tz=local`` flag to the execution command above.
+    By default, the Podman containers are either built with the local timezone
+    or to the UTC. To change the timezone of the container, add ``--tz=local``
+    flag to the execution command above.
 
 Run a python script
 -------------------
@@ -33,11 +33,6 @@ Run a python script
     Run ``cd ${CNEUROMAX_PATH}/cneuromax`` before the following command to get
     tab completion for the ``task`` argument.
 
-.. note::
-    By default, Docker's local timezone is set to UTC, and all the Docker operations
-    will run according to UTC regardless of the host machine's timezone. If you
-    would like to set it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE``
-    flag to the execution command below.
 
 .. code-block:: bash
 

--- a/docs/Execution_On_an_Ubuntu_machine.rst
+++ b/docs/Execution_On_an_Ubuntu_machine.rst
@@ -19,8 +19,8 @@ On an Ubuntu machine
 
     Make sure to remove the above flags if you are not using a GPU.
 
-.. note:: 
-    By default, the Podman container's timezone is either set to the timezone of the local 
+.. note::
+    By default, the Podman container's timezone is either set to the timezone of the local
     where it is built or to the UTC. To change the timezone of the container, add
     ``--tz=local`` flag to the execution command above.
 
@@ -35,8 +35,8 @@ Run a python script
 
 .. note::
     By default, Docker's local timezone is set to UTC, and all the Docker operations
-    will run according to UTC regardless of the host machine's timezone. If you 
-    would like to set it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE`` 
+    will run according to UTC regardless of the host machine's timezone. If you
+    would like to set it to a specific timezone, please add ``--env TZ= YOUR_TIMEZONE``
     flag to the execution command below.
 
 .. code-block:: bash


### PR DESCRIPTION
This PR adds:

* Recommendation for adding a timezone flag to set the timezone of the Docker, Podman, and Apptainer containers to the local/preferred timezone. 
* Adds a warning for Maestral's lag in the first initialization in Slurms. 