### PR TITLE
enhanced w&b logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 WANDB_KEY.txt
 test.ipynb
 cneuromax/fitting/neuroevolution/space/imitation.py
+test/
+test.wav

--- a/cneuromax/config.py
+++ b/cneuromax/config.py
@@ -21,7 +21,7 @@ from hydra import types as ht
 from hydra.experimental.callbacks import LogJobReturnCallback
 from hydra_zen import make_config
 
-from cneuromax.utils.beartype import not_empty
+from cneuromax.utils.beartype import ge, not_empty
 from cneuromax.utils.hydra_zen import fs_builds
 
 
@@ -36,10 +36,12 @@ class BaseSubtaskConfig:
         data_dir: Path to the data directory. This directory is\
             shared between ``task`` runs. It is used to store\
             datasets, pre-trained models, etc.
+        seed: Random seed to use for reproducibility.
     """
 
     output_dir: An[str, not_empty()] = "${hydra:runtime.output_dir}"
     data_dir: An[str, not_empty()] = "${oc.env:CNEUROMAX_PATH}/data/"
+    seed: An[int, ge(0)] = 0
 
 
 @dataclass

--- a/cneuromax/fitting/deeplearning/datamodule/base.py
+++ b/cneuromax/fitting/deeplearning/datamodule/base.py
@@ -164,7 +164,7 @@ class BaseDataModule(LightningDataModule, metaclass=ABCMeta):
             A new validation :class:`~torch.utils.data.DataLoader`\
                 instance.
         """
-        return self.x_dataloader(dataset=self.datasets.val)
+        return self.x_dataloader(dataset=self.datasets.val, shuffle=False)
 
     @final
     def test_dataloader(self: "BaseDataModule") -> DataLoader[Tensor]:
@@ -174,7 +174,7 @@ class BaseDataModule(LightningDataModule, metaclass=ABCMeta):
             A new testing :class:`~torch.utils.data.DataLoader`\
                 instance.
         """
-        return self.x_dataloader(dataset=self.datasets.test)
+        return self.x_dataloader(dataset=self.datasets.test, shuffle=False)
 
     @final
     def predict_dataloader(self: "BaseDataModule") -> DataLoader[Tensor]:

--- a/cneuromax/fitting/deeplearning/litmodule/classification/base.py
+++ b/cneuromax/fitting/deeplearning/litmodule/classification/base.py
@@ -1,12 +1,16 @@
 """:class:`BaseClassificationLitModule` & its config."""
 
 from abc import ABCMeta
+from collections.abc import Callable  # noqa: TCH003
+from copy import copy
 from dataclasses import dataclass
 from functools import partial
 from typing import Annotated as An
+from typing import Any
 
 import torch
 import torch.nn.functional as f
+import wandb
 from jaxtyping import Float, Int
 from torch import Tensor, nn
 from torch.optim import Optimizer
@@ -40,6 +44,9 @@ class BaseClassificationLitModule(BaseLitModule, metaclass=ABCMeta):
     Attributes:
         accuracy\
             (:class:`~torchmetrics.classification.MulticlassAccuracy`)
+        wandb_input_data_wrapper (:`callable`): A wrapper to be used\
+            around the input datapoint when logging to W&B.
+        wandb_table: A W&B table to store validation data.
     """
 
     def __init__(
@@ -54,8 +61,14 @@ class BaseClassificationLitModule(BaseLitModule, metaclass=ABCMeta):
             optimizer=optimizer,
             scheduler=scheduler,
         )
+        # Accuracy metric.
         self.accuracy: MulticlassAccuracy = MulticlassAccuracy(
             num_classes=config.num_classes,
+        )
+        # W&B validation attributes.
+        self.wandb_input_data_wrapper: Callable[..., Any] = lambda x: x
+        self.wandb_table: wandb.Table = wandb.Table(  # type: ignore[no-untyped-call]
+            columns=["idx", "epoch", "x", "y", "probs", "pred"],
         )
 
     def step(
@@ -83,4 +96,53 @@ class BaseClassificationLitModule(BaseLitModule, metaclass=ABCMeta):
         preds: Int[Tensor, " batch_size"] = torch.argmax(input=logits, dim=1)
         accuracy: Float[Tensor, " "] = self.accuracy(preds=preds, target=y)
         self.log(name=f"{stage}/acc", value=accuracy)
+        if stage == "val":
+            self.save_val_data(x=x, y=y, logits=logits, preds=preds)
         return f.cross_entropy(input=logits, target=y)
+
+    def save_val_data(
+        self: "BaseClassificationLitModule",
+        x: Float[Tensor, " batch_size *x_shape"],
+        y: Int[Tensor, " batch_size"],
+        logits: Float[Tensor, " batch_size num_classes"],
+        preds: Int[Tensor, " batch_size"],
+    ) -> None:
+        """Saves data computed during validation for later use.
+
+        Args:
+            x: The input data.
+            y: The target data.
+            logits: The network's raw output.
+            preds: The model's predictions.
+        """
+        x = x.cpu().numpy()
+        y = y.cpu().numpy()
+        probs = f.softmax(input=logits, dim=1).cpu().numpy()
+        preds = preds.cpu().numpy()
+        for x_i, y_i, probs_i, preds_i in zip(
+            x,
+            y,
+            probs,
+            preds,
+            strict=False,
+        ):
+            self.val_data.append([x_i, y_i, probs_i, preds_i])
+
+    def on_validation_epoch_end(self: "BaseClassificationLitModule") -> None:
+        """Called at the end of the validation epoch."""
+        for i, val_data in enumerate(self.val_data):
+            x_i, y_i, probs_i, preds_i = val_data
+            self.wandb_table.add_data(  # type: ignore[no-untyped-call]
+                i,
+                self.curr_val_epoch,
+                self.wandb_input_data_wrapper(x_i),
+                y_i,
+                probs_i.tolist(),
+                preds_i,
+            )
+        # 1) Static type checking discrepancy:
+        # `logger.experiment` is a `wandb.wandb_run.Run` instance.
+        # 2) Cannot log the same table twice:
+        # https://github.com/wandb/wandb/issues/2981#issuecomment-1458447291
+        self.logger.experiment.log({"val_data": copy(self.wandb_table)})  # type: ignore[union-attr]
+        super().on_validation_epoch_end()

--- a/cneuromax/fitting/deeplearning/train.py
+++ b/cneuromax/fitting/deeplearning/train.py
@@ -15,6 +15,7 @@ from cneuromax.fitting.deeplearning.utils.lightning import (
     set_batch_size_and_num_workers,
     set_checkpoint_path,
 )
+from cneuromax.utils.misc import seed_all
 
 
 def train(
@@ -44,6 +45,7 @@ def train(
     Returns:
         The final validation loss.
     """
+    seed_all(config.seed)
     full_trainer, full_logger = instantiate_trainer_and_logger(
         partial_trainer=trainer,
         partial_logger=logger,

--- a/cneuromax/fitting/deeplearning/utils/lightning.py
+++ b/cneuromax/fitting/deeplearning/utils/lightning.py
@@ -231,7 +231,7 @@ def find_good_per_device_num_workers(
         logging.info("Only 1 worker available/provided. Returning 0.")
         return 0
     times = []
-    for num_workers in range(launcher_config.cpus_per_task or 1 + 1):
+    for num_workers in range((launcher_config.cpus_per_task or 1) + 1):
         datamodule_copy = copy.deepcopy(datamodule)
         datamodule_copy.per_device_batch_size = per_device_batch_size
         datamodule_copy.per_device_num_workers = num_workers

--- a/cneuromax/fitting/neuroevolution/fit.py
+++ b/cneuromax/fitting/neuroevolution/fit.py
@@ -90,6 +90,7 @@ def evolve(
         logger: See :func:`~.utils.wandb.setup_wandb`.
         config: See :class:`.NeuroevolutionSubtaskConfig`.
     """
+    seed_all(config.seed)
     comm, _, _ = get_mpi_variables()
     validate_space(space=space, pop_merge=config.pop_merge)
     save_points = compute_save_points(

--- a/cneuromax/projects/classify_mnist/__init__.py
+++ b/cneuromax/projects/classify_mnist/__init__.py
@@ -5,16 +5,13 @@ from hydra_zen import ZenStore
 from cneuromax.fitting.deeplearning.runner import DeepLearningTaskRunner
 from cneuromax.utils.hydra_zen import fs_builds
 
-from .datamodule import (
-    MNISTClassificationDataModule,
-    MNISTClassificationDataModuleConfig,
-)
+from .datamodule import MNISTDataModule, MNISTDataModuleConfig
 from .litmodule import MNISTClassificationLitModule
 
 __all__ = [
     "TaskRunner",
-    "MNISTClassificationDataModuleConfig",
-    "MNISTClassificationDataModule",
+    "MNISTDataModuleConfig",
+    "MNISTDataModule",
     "MNISTClassificationLitModule",
 ]
 
@@ -31,11 +28,8 @@ class TaskRunner(DeepLearningTaskRunner):
         """
         super().store_configs(store=store)
         store(
-            fs_builds(
-                MNISTClassificationDataModule,
-                config=MNISTClassificationDataModuleConfig(),
-            ),
-            name="classify_mnist",
+            fs_builds(MNISTDataModule, config=MNISTDataModuleConfig()),
+            name="mnist",
             group="datamodule",
         )
         store(

--- a/cneuromax/projects/classify_mnist/datamodule.py
+++ b/cneuromax/projects/classify_mnist/datamodule.py
@@ -1,4 +1,4 @@
-""":class:`MNISTClassificationDataModule` & its config."""
+""":class:`MNISTDataModule` & its config."""
 
 from dataclasses import dataclass
 from typing import Annotated as An
@@ -15,22 +15,22 @@ from cneuromax.utils.beartype import ge, lt, one_of
 
 
 @dataclass
-class MNISTClassificationDataModuleConfig(BaseDataModuleConfig):
-    """Holds :class:`MNISTClassificationDataModule` config values.
+class MNISTDataModuleConfig(BaseDataModuleConfig):
+    """Holds :class:`MNISTDataModule` config values.
 
     Args:
         val_percentage: Percentage of the training dataset to use for\
             validation.
     """
 
-    val_percentage: An[float, ge(0), lt(1)] = 0.1
+    val_percentage: An[float, ge(0), lt(1)] = 0.005
 
 
-class MNISTClassificationDataModule(BaseDataModule):
+class MNISTDataModule(BaseDataModule):
     """``project`` :class:`.BaseDataModule`.
 
     Args:
-        config: See :class:`MNISTClassificationDataModuleConfig`.
+        config: See :class:`MNISTDataModuleConfig`.
 
     Attributes:
         train_val_split (`tuple[float, float]`): The train/validation\
@@ -40,8 +40,8 @@ class MNISTClassificationDataModule(BaseDataModule):
     """
 
     def __init__(
-        self: "MNISTClassificationDataModule",
-        config: MNISTClassificationDataModuleConfig,
+        self: "MNISTDataModule",
+        config: MNISTDataModuleConfig,
     ) -> None:
         super().__init__(config=config)
         self.train_val_split = (
@@ -51,16 +51,17 @@ class MNISTClassificationDataModule(BaseDataModule):
         self.transform = transforms.Compose(
             [
                 transforms.ToTensor(),
+                # Pre-computer mean and std for the MNIST dataset.
                 transforms.Normalize(mean=(0.1307,), std=(0.3081,)),
             ],
         )
 
-    def prepare_data(self: "MNISTClassificationDataModule") -> None:
+    def prepare_data(self: "MNISTDataModule") -> None:
         """Downloads the MNIST dataset."""
         MNIST(root=self.config.data_dir, download=True)
 
     def setup(
-        self: "MNISTClassificationDataModule",
+        self: "MNISTDataModule",
         stage: An[str, one_of("fit", "validate", "test")],
     ) -> None:
         """Creates the train/val/test datasets.

--- a/cneuromax/projects/classify_mnist/datamodule_test.py
+++ b/cneuromax/projects/classify_mnist/datamodule_test.py
@@ -7,24 +7,23 @@ from torch.utils.data import Subset
 from torchvision.datasets import MNIST
 
 from . import (
-    MNISTClassificationDataModule,
-    MNISTClassificationDataModuleConfig,
+    MNISTDataModule,
+    MNISTDataModuleConfig,
 )
 
 
 @pytest.fixture()
-def datamodule(tmp_path: Path) -> MNISTClassificationDataModule:
-    """:class:`~.MNISTClassificationDataModule` fixture.
+def datamodule(tmp_path: Path) -> MNISTDataModule:
+    """:class:`~.MNISTDataModule` fixture.
 
     Args:
-        tmp_path: The temporary path for the\
-            :class:`~.MNISTClassificationDataModule`.
+        tmp_path: The temporary path for the :class:`~.MNISTDataModule`.
 
     Returns:
-        A generic :class:`~.MNISTClassificationDataModule` instance.
+        A generic :class:`~.MNISTDataModule` instance.
     """
-    return MNISTClassificationDataModule(
-        MNISTClassificationDataModuleConfig(
+    return MNISTDataModule(
+        MNISTDataModuleConfig(
             data_dir=str(tmp_path) + "/",
             device="cpu",
             val_percentage=0.1,
@@ -32,16 +31,15 @@ def datamodule(tmp_path: Path) -> MNISTClassificationDataModule:
     )
 
 
-def test_setup_fit(datamodule: MNISTClassificationDataModule) -> None:
-    """Tests :meth:`~.MNISTClassificationDataModule.setup` #1.
+def test_setup_fit(datamodule: MNISTDataModule) -> None:
+    """Tests :meth:`~.MNISTDataModule.setup` #1.
 
-    Verifies that :func:`~.MNISTClassificationDataModule.setup` behaves
-    correctly when
-    :paramref:`~.MNISTClassificationDataModule.setup.stage` is
+    Verifies that :func:`~.MNISTDataModule.setup` behaves
+    correctly when :paramref:`~.MNISTDataModule.setup.stage` is
     ``"fit"``.
 
     Args:
-        datamodule: A generic :class:`~.MNISTClassificationDataModule`\
+        datamodule: A generic :class:`~.MNISTDataModule`\
             instance, see :func:`datamodule`.
     """
     datamodule.prepare_data()
@@ -54,16 +52,15 @@ def test_setup_fit(datamodule: MNISTClassificationDataModule) -> None:
     assert len(datamodule.datasets.val) == 6000
 
 
-def test_setup_test(datamodule: MNISTClassificationDataModule) -> None:
-    """Tests :meth:`~.MNISTClassificationDataModule.setup` #2.
+def test_setup_test(datamodule: MNISTDataModule) -> None:
+    """Tests :meth:`~.MNISTDataModule.setup` #2.
 
-    Verifies that :func:`~.MNISTClassificationDataModule.setup` behaves
-    correctly when
-    :paramref:`~.MNISTClassificationDataModule.setup.stage` is
+    Verifies that :func:`~.MNISTDataModule.setup` behaves
+    correctly when :paramref:`~.MNISTDataModule.setup.stage` is
     ``"test"``.
 
     Args:
-        datamodule: A generic :class:`~.MNISTClassificationDataModule`\
+        datamodule: A generic :class:`~.MNISTDataModule`\
             instance, see :func:`datamodule`.
     """
     datamodule.prepare_data()

--- a/cneuromax/projects/classify_mnist/litmodule.py
+++ b/cneuromax/projects/classify_mnist/litmodule.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 
+import wandb
 from torch import nn
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
@@ -33,3 +34,4 @@ class MNISTClassificationLitModule(BaseClassificationLitModule):
             optimizer=optimizer,
             scheduler=scheduler,
         )
+        self.wandb_input_data_wrapper = wandb.Image

--- a/cneuromax/projects/classify_mnist/task/mlp.yaml
+++ b/cneuromax/projects/classify_mnist/task/mlp.yaml
@@ -1,11 +1,12 @@
 # @package _global_
 defaults:
-  - /datamodule: classify_mnist
+  - /datamodule: mnist
   - /litmodule: classify_mnist
   - _self_
 hydra:
   launcher:
     gpus_per_node: 1
+    cpus_per_task: 4
 config:
   device: gpu
 litmodule:


### PR DESCRIPTION
Enhanced validation W&B logging (images, y, probs, preds) , see https://wandb.ai/cneuroml/classify_mnist

Changes:
- Added logic to log W&B validation data (see `BaseLitModule`, `BaseClassificationLitModule` & `MNISTClassificationLitModule`)
- Renamed `MNISTClassificationDataModule` to `MNISTDataModule`
- Add a `seed` `BaseSubtaskConfig` option for reproducibility
- No more shuffling `val` & `test` dataset (for w&b logging consistency)
- Adding `cpus_per_task` option in MNIST example
- Fixed `num_workers` finder capping at 2 workers